### PR TITLE
protecao nas rotas

### DIFF
--- a/necchange/src/app/api/feed/feed_post/accept_trade/route.js
+++ b/necchange/src/app/api/feed/feed_post/accept_trade/route.js
@@ -7,8 +7,11 @@ export async function POST(req, context) {
   const data = await req.json();
 
   // student that accepted the trade
-  const fromStudentNr = data.fromStudentNr;
+  const fromStudentNr = data.params.fromStudentNr;
   const studentNrAccepted = data.params.studentAcceptedNr;
+
+  console.log("fromStudentNr", fromStudentNr);
+  console.log("studentNrAccepted", studentNrAccepted);
 
   if (fromStudentNr == studentNrAccepted) {
     return new NextResponse(

--- a/necchange/src/app/api/feed/feed_post/accept_trade/route.js
+++ b/necchange/src/app/api/feed/feed_post/accept_trade/route.js
@@ -9,8 +9,14 @@ export async function POST(req, context) {
   // student that accepted the trade
   const fromStudentNr = data.fromStudentNr;
   const studentNrAccepted = data.params.studentAcceptedNr;
-  const tradeId = data.params.tradeId;
 
+  if (fromStudentNr == studentNrAccepted) {
+    return new NextResponse(
+      JSON.stringify({ response: "Not authorized to accept this trade" })
+    );
+  }
+
+  const tradeId = data.params.tradeId;
 
   const accept_query = await prisma.$transaction(async (tx) => {
     const getToStudentId = await tx.user.findFirst({
@@ -107,7 +113,7 @@ export async function POST(req, context) {
     return false;
   });
 
-  await prisma.$disconnect()
+  await prisma.$disconnect();
   return new NextResponse(JSON.stringify({ response: accept_query }));
 }
 
@@ -189,7 +195,6 @@ async function deleteDeprecatedTrades(fromStudentId, toStudentId, tradeId, tx) {
     },
   });
 
-  
   return new NextResponse(JSON.stringify({ response: true }));
 }
 

--- a/necchange/src/app/api/feed/feed_post/trade_period_info/route.js
+++ b/necchange/src/app/api/feed/feed_post/trade_period_info/route.js
@@ -13,7 +13,7 @@ export async function GET(req, context) {
     },
   });
 
-  if (trades_status?.openDate && trades_status?.closeDate) {
+  if (trades_status.openDate && trades_status?.closeDate) {
     const date = new Date();
     const is_open =
       date > trades_status.openDate && date < trades_status.closeDate

--- a/necchange/src/app/api/users/user_courses/[student_nr]/route.js
+++ b/necchange/src/app/api/users/user_courses/[student_nr]/route.js
@@ -1,10 +1,18 @@
 import { PrismaClient } from "@prisma/client";
+import { getToken } from "next-auth/jwt";
 import { NextRequest, NextResponse } from "next/server";
 
 const prisma = new PrismaClient();
 
 export async function GET(req, context) {
+  const token = await getToken({ req });
   const student_nr = context.params.student_nr;
+
+  if (token.role != "SUPER_USER" && token.number != student_nr) {
+    return new NextResponse(
+      JSON.stringify({ status: "error", error: "Not authorized" })
+    );
+  }
 
   try {
     const student_ucs = await prisma.student_lesson.findMany({
@@ -22,11 +30,13 @@ export async function GET(req, context) {
       },
     });
 
-    const return_student_ucs = student_ucs.filter(student_uc => student_uc.lesson_id != null)
+    const return_student_ucs = student_ucs.filter(
+      (student_uc) => student_uc.lesson_id != null
+    );
 
-    return_student_ucs.map((bla) =>console.log(bla))
+    return_student_ucs.map((bla) => console.log(bla));
 
-    await prisma.$disconnect()
+    await prisma.$disconnect();
     return new NextResponse(
       JSON.stringify({ status: "ok", student_ucs: return_student_ucs })
     );

--- a/necchange/src/middleware.js
+++ b/necchange/src/middleware.js
@@ -11,7 +11,7 @@ import { getToken } from "next-auth/jwt";
  *
  */
 const publicRoutes = ["/"];
-const authRoutes = ["/auth", "/api/feed"];
+const authRoutes = ["/auth"];
 const adminRoutes = ["/super_user", "/api/admin", "/api/users/delete_user", "/api/users/user_profile"];
 const protectedRoutes = ["/profile", "/horario", "/feed"];
 

--- a/necchange/src/middleware.js
+++ b/necchange/src/middleware.js
@@ -11,9 +11,8 @@ import { getToken } from "next-auth/jwt";
  *
  */
 const publicRoutes = ["/"];
-const authRoutes = ["/auth"];
-// for now, horario and feed are protected routes. When necchange is full released, change that routes to protected
-const adminRoutes = ["/super_user"];
+const authRoutes = ["/auth", "/api/feed"];
+const adminRoutes = ["/super_user", "/api/admin", "/api/users/delete_user", "/api/users/user_profile"];
 const protectedRoutes = ["/profile", "/horario", "/feed"];
 
 export async function middleware(request) {


### PR DESCRIPTION
Adicionei protecao no api/feed/feed_post/accept-trade para o estudante que criou uma troca nao poder aceitar a propria troca
Adicionei tambem no api/users/user_courses/[student_nr] para só o estudante loggedin ou admin poder ver
E no middleware a protejer /api/feed so para autenticados, e "/api/admin", "/api/users/delete_user", "/api/users/user_profile" so para admins